### PR TITLE
Remove psr logger interface.

### DIFF
--- a/src/Commands/FixityCheck.php
+++ b/src/Commands/FixityCheck.php
@@ -18,13 +18,6 @@ class FixityCheck extends DrushCommands {
   use StringTranslationTrait;
 
   /**
-   * A logger instance.
-   *
-   * @var \Psr\Log\LoggerInterface
-   */
-  protected $logger;
-
-  /**
    * The entity type manager.
    *
    * @var \Drupal\Core\Entity\EntityTypeManagerInterface


### PR DESCRIPTION
I get this in Drupal 10 with Drush 11.

```
PHP Fatal error:  Type of Drupal\dgi_fixity\Commands\FixityCheck::$logger must be ?Psr\Log\LoggerInterface (as in class Drush\Commands\DrushCommands) in /var/www/html/drupal/web/modules/contrib/dgi_fixity/src/Commands/FixityCheck.php on line 16
```

From what I can tell, it is a Drush 11 and Drupal 10 issue, and just removing this is a patch in a few instances. It's working for me on my end, and figured I'd share back. Though, not 100% sure it is the best fix.

Thanks for creating this module!

