### PR TITLE
D10-68: Handling  ${var} deprecation.

### DIFF
--- a/src/Commands/FixityCheck.php
+++ b/src/Commands/FixityCheck.php
@@ -50,7 +50,7 @@ class FixityCheck extends DrushCommands {
     /** @var \Drupal\dgi_fixity\FixityCheckStorageInterface $storage */
     $storage = $this->entityTypeManager->getStorage('fixity_check');
     $count = $storage->countPeriodic();
-    if ($this->io()->confirm("This will remove periodic checks on ${count} files, are you sure?", FALSE)) {
+    if ($this->io()->confirm("This will remove periodic checks on {$count} files, are you sure?", FALSE)) {
       $storage->clearPeriodic();
     }
   }


### PR DESCRIPTION
Handling a deprecation notice ```PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/web/modules/contrib/dgi_fixity/src/Commands/FixityCheck.php on line 53```