### PR TITLE
BCIR-270: Delete fixity_check entities if there aren't any files attached

### DIFF
--- a/src/Entity/FixityCheck.php
+++ b/src/Entity/FixityCheck.php
@@ -208,7 +208,13 @@ class FixityCheck extends ContentEntityBase implements FixityCheckInterface {
   public function getFile(): ?File {
     /** @var \Drupal\Core\Field\EntityReferenceFieldItemList $file */
     $file = $this->file;
-    return $file->isEmpty() ? NULL : $file->referencedEntities()[0];
+
+    if ($file->isEmpty()) {
+      return NULL;
+    }
+
+    $referenced_entities = $file->referencedEntities();
+    return !empty($referenced_entities) ? reset($referenced_entities) : NULL;
   }
 
   /**

--- a/src/Plugin/QueueWorker/FixityCheckWorker.php
+++ b/src/Plugin/QueueWorker/FixityCheckWorker.php
@@ -7,6 +7,7 @@ use Drupal\Core\Queue\QueueWorkerBase;
 use Drupal\dgi_fixity\FixityCheckServiceInterface;
 use Drupal\dgi_fixity\FixityCheckInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use function PHPUnit\Framework\isEmpty;
 
 /**
  * Performs a fixity check.
@@ -60,6 +61,10 @@ class FixityCheckWorker extends QueueWorkerBase implements ContainerFactoryPlugi
    */
   public function processItem($data) {
     if ($data instanceof FixityCheckInterface) {
+      if (isEmpty($data->getFile())) {
+        $data->delete();
+        return;
+      }
       /** @var \Drupal\dgi_fixity\FixityCheckInterface $data */
       $this->fixity->check($data->getFile());
     }

--- a/src/Plugin/QueueWorker/FixityCheckWorker.php
+++ b/src/Plugin/QueueWorker/FixityCheckWorker.php
@@ -7,7 +7,6 @@ use Drupal\Core\Queue\QueueWorkerBase;
 use Drupal\dgi_fixity\FixityCheckServiceInterface;
 use Drupal\dgi_fixity\FixityCheckInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use function PHPUnit\Framework\isEmpty;
 
 /**
  * Performs a fixity check.
@@ -61,7 +60,7 @@ class FixityCheckWorker extends QueueWorkerBase implements ContainerFactoryPlugi
    */
   public function processItem($data) {
     if ($data instanceof FixityCheckInterface) {
-      if (isEmpty($data->getFile())) {
+      if (empty($data->getFile())) {
         $data->delete();
         return;
       }


### PR DESCRIPTION
Also fixed the `getFile` function which didn't check referenced entities for empty arrays.

This case is rare and should only occur whenever files are deleted and somehow the delete hooks in the `.module` file don't catch it.