### PR TITLE
[DGI9-522] Allow FixityCheckBatchCheck to advance to the next batch

### DIFF
--- a/src/FixityCheckBatchCheck.php
+++ b/src/FixityCheckBatchCheck.php
@@ -170,7 +170,7 @@ class FixityCheckBatchCheck {
     $results = &$context['results'];
     if (!isset($sandbox['offset'])) {
       $sandbox['offset'] = 0;
-      $sandbox['remaining'] = $storage->countPeriodic();
+      $sandbox['count'] = $storage->countPeriodic();
       $results['successful'] = 0;
       $results['ignored'] = 0;
       $results['skipped'] = 0;
@@ -179,7 +179,8 @@ class FixityCheckBatchCheck {
     }
 
     $files = $storage->getPeriodic($sandbox['offset'], $batch_size);
-    $end = min($sandbox['remaining'], $sandbox['offset'] + count($files));
+
+    $end = min($sandbox['count'], $sandbox['offset'] + count($files));
     $context['message'] = \t('Processing @start to @end', [
       '@start' => $sandbox['offset'],
       '@end' => $end,
@@ -187,12 +188,7 @@ class FixityCheckBatchCheck {
     static::check($files, $force, $results);
     $sandbox['offset'] = $end;
 
-    $remaining = $storage->countPeriodic();
-    $progress_halted = $sandbox['remaining'] == $remaining;
-    $sandbox['remaining'] = $remaining;
-
-    // End when we have exhausted all inputs or progress has halted.
-    $context['finished'] = empty($files) || $progress_halted;
+    $context['finished'] = ($sandbox['count'] <= $end);
   }
 
   /**


### PR DESCRIPTION
The "remaining" sandbox property was simply set to the count of all periodic checks which was caused `$progress_halted` to always return `True` which set the "finished" property at the end of the first batch.

This PR renames 'remaining' to 'count' to more accurately reflect what it represents and removes the erroneous end condition.

Resolves #16 and replaces #18, which didn't work when I tested it.