### PR TITLE
display configured batch size in form

### DIFF
--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -155,7 +155,7 @@ class SettingsForm extends ConfigFormBase {
         '#description' => $this->t('
           <p>Set how many files will be processed at once when performing a batch / cron job</p>
         '),
-        '#default_value' => 100,
+        '#default_value' => $config->get(static::BATCH_SIZE) ?: 100,
       ],
     ];
 

--- a/src/Plugin/QueueWorker/FixityCheckWorker.php
+++ b/src/Plugin/QueueWorker/FixityCheckWorker.php
@@ -4,8 +4,8 @@ namespace Drupal\dgi_fixity\Plugin\QueueWorker;
 
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Queue\QueueWorkerBase;
-use Drupal\dgi_fixity\FixityCheckServiceInterface;
 use Drupal\dgi_fixity\FixityCheckInterface;
+use Drupal\dgi_fixity\FixityCheckServiceInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**


### PR DESCRIPTION
The batch size was getting set on form submission, but continuing to only display 100 in the form regardless of the configured value after changing it. It's a super small fix so I just put this together in hopes someone has time to quickly review, test, and merge.

To test:
- in a site with this module enabled, go to {site url}/admin/config/fixity
- set a value for 'Batch size' that is different from 100
- save the form
- without this fix: the form will continue to display 'Batch size' as 100 (though functionally the saved value is used)
- with this fix: the form will display the actual configured value for 'Batch size'