### PR TITLE
Fix type error in dgi_fixity:check for better drush compatibility.

### DIFF
--- a/src/Commands/FixityCheck.php
+++ b/src/Commands/FixityCheck.php
@@ -24,6 +24,13 @@ class FixityCheck extends DrushCommands {
    */
   protected $entityTypeManager;
 
+   /**
+   * The fixity logger.
+   *
+   * `@var` \Psr\Log\LoggerInterface
+   */
+  protected $fixityLogger;
+
   /**
    * Creates the drush command object.
    *
@@ -34,10 +41,12 @@ class FixityCheck extends DrushCommands {
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity manager.
    */
-  public function __construct(TranslationInterface $string_translation, LoggerInterface $logger, EntityTypeManagerInterface $entity_type_manager) {
+  public function __construct(TranslationInterface $string_translation, LoggerInterface $fixityLogger, EntityTypeManagerInterface $entity_type_manager) {
     parent::__construct();
     $this->stringTranslation = $string_translation;
-    $this->logger = $logger;
+
+    // this logger logs to the "fixity" channel (unlike $this->logger which drush sets up).
+    $this->fixityLogger = $fixityLogger;
     $this->entityTypeManager = $entity_type_manager;
   }
 
@@ -92,7 +101,7 @@ class FixityCheck extends DrushCommands {
           $fids = explode("\n", trim(file_get_contents($fids)));
         }
         else {
-          $this->logger->error($this->t('Cannot read file @file', ['@file' => $fids]));
+          $this->fixityLogger->error($this->t('Cannot read file @file', ['@file' => $fids]));
           return;
         }
       }

--- a/src/Commands/FixityCheck.php
+++ b/src/Commands/FixityCheck.php
@@ -24,11 +24,11 @@ class FixityCheck extends DrushCommands {
    */
   protected $entityTypeManager;
 
-   /**
-    * The fixity logger.
-    *
-    * @var \Psr\Log\LoggerInterface
-    */
+  /**
+   * The fixity logger.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
   protected $fixityLogger;
 
   /**

--- a/src/Commands/FixityCheck.php
+++ b/src/Commands/FixityCheck.php
@@ -45,8 +45,9 @@ class FixityCheck extends DrushCommands {
     parent::__construct();
     $this->stringTranslation = $string_translation;
 
-    // XXX: Not using `$this->logger` to avoid potential oddities with our more-specific
-    // logger being used in other contexts should it be registered with the logger manager.
+    // XXX: Not using `$this->logger` to avoid potential oddities with our more-
+    // specific logger being used in other contexts should it be registered with
+    // the logger manager.
     $this->fixityLogger = $fixityLogger;
     $this->entityTypeManager = $entity_type_manager;
   }

--- a/src/Commands/FixityCheck.php
+++ b/src/Commands/FixityCheck.php
@@ -45,7 +45,8 @@ class FixityCheck extends DrushCommands {
     parent::__construct();
     $this->stringTranslation = $string_translation;
 
-    // this logger logs to the "fixity" channel (unlike $this->logger which drush sets up).
+    // XXX: Not using `$this->logger` to avoid potential oddities with our more-specific
+    // logger being used in other contexts should it be registered with the logger manager.
     $this->fixityLogger = $fixityLogger;
     $this->entityTypeManager = $entity_type_manager;
   }

--- a/src/Commands/FixityCheck.php
+++ b/src/Commands/FixityCheck.php
@@ -27,7 +27,7 @@ class FixityCheck extends DrushCommands {
    /**
    * The fixity logger.
    *
-   * `@var` \Psr\Log\LoggerInterface
+   * @var \Psr\Log\LoggerInterface
    */
   protected $fixityLogger;
 

--- a/src/Commands/FixityCheck.php
+++ b/src/Commands/FixityCheck.php
@@ -25,10 +25,10 @@ class FixityCheck extends DrushCommands {
   protected $entityTypeManager;
 
    /**
-   * The fixity logger.
-   *
-   * @var \Psr\Log\LoggerInterface
-   */
+    * The fixity logger.
+    *
+    * @var \Psr\Log\LoggerInterface
+    */
   protected $fixityLogger;
 
   /**

--- a/src/Commands/FixityCheck.php
+++ b/src/Commands/FixityCheck.php
@@ -36,7 +36,7 @@ class FixityCheck extends DrushCommands {
    *
    * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
    *   The translation manager.
-   * @param \Psr\Log\LoggerInterface $logger
+   * @param \Psr\Log\LoggerInterface $fixityLogger
    *   A logger instance.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity manager.


### PR DESCRIPTION
I recently installed this module for the first time.  When using it I got this error:

```
TypeError: Drush\Commands\DrushCommands::logger(): Return value must be of type ?Drush\Log\DrushLoggerManager, Drupal\Core\Logger\LoggerChannel returned in Drush\Commands\DrushCommands->logger() (line 77 of /var/www/drupal/vendor/drush/drush/src/Commands/DrushCommands.php)

#0 /var/www/drupal/vendor/drush/drush/src/Runtime/ServiceManager.php(480): Drush\Commands\DrushCommands->logger()
#1 /var/www/drupal/vendor/drush/drush/src/Boot/DrupalBoot8.php(284): Drush\Runtime\ServiceManager->inflect()
#2 /var/www/drupal/vendor/drush/drush/src/Boot/DrupalBoot8.php(220): Drush\Boot\DrupalBoot8->addDrupalModuleDrushCommands()
#3 /var/www/drupal/vendor/drush/drush/src/Boot/BootstrapManager.php(211): Drush\Boot\DrupalBoot8->bootstrapDrupalFull()
#4 /var/www/drupal/vendor/drush/drush/src/Boot/BootstrapManager.php(397): Drush\Boot\BootstrapManager->doBootstrap()
#5 /var/www/drupal/vendor/drush/drush/src/Application.php(219): Drush\Boot\BootstrapManager->bootstrapMax()
#6 /var/www/drupal/vendor/drush/drush/src/Application.php(185): Drush\Application->bootstrapAndFind()
#7 /var/www/drupal/vendor/symfony/console/Application.php(266): Drush\Application->find()
#8 /var/www/drupal/vendor/symfony/console/Application.php(175): Symfony\Component\Console\Application->doRun()
#9 /var/www/drupal/vendor/drush/drush/src/Runtime/Runtime.php(110): Symfony\Component\Console\Application->run()
#10 /var/www/drupal/vendor/drush/drush/src/Runtime/Runtime.php(40): Drush\Runtime\Runtime->doRun()
#11 /var/www/drupal/vendor/drush/drush/drush.php(140): Drush\Runtime\Runtime->run()
#12 /var/www/drupal/vendor/bin/drush.php(119): include('/var/www/drupal...')
#13 {main}
```

I'm using drush 13.6.  After some analysis I believe that this error comes up when used with newer drush versions (13+ I think) , due to some logging-related changes in drush and the default logger it provides to instances of `DrushCommands`.
References:
https://github.com/drush-ops/drush/pull/5022
https://github.com/drush-ops/drush/pull/5963

In the dgi_fixity code, it seemed important that the existing logger call in this command (Cannot read file @file) shows up under the "fixity" logging channel, so this PR takes that approach.  The alternative would be to remove $fixity_logger entirely and simply use the default logger ($this->logger) which drush initializes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved logging for fixity check operations: error messages for unreadable files are now routed to a dedicated fixity log channel, providing clearer, more precise diagnostics and better separation of concerns to aid troubleshooting and monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->